### PR TITLE
Make scanning of comments lazy

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const tagRegexp = /^<[\/\w][^>]*>/;
-const commentRegexp = /^<!--[\w\W]*-->/;
+const commentRegexp = /^<!--[\w\W]*?-->/;
 const digitRegexp = /\d/;
 
 module.exports = class Tokenizer {

--- a/test/list-cases/comment-at-end.ecmarkdown
+++ b/test/list-cases/comment-at-end.ecmarkdown
@@ -1,0 +1,2 @@
+1. foo <!-- comment -->
+1. bar <!-- comment -->

--- a/test/list-cases/comment-at-end.html
+++ b/test/list-cases/comment-at-end.html
@@ -1,0 +1,8 @@
+<ol>
+  <li>foo
+    <!-- comment -->
+  </li>
+  <li>bar
+    <!-- comment -->
+  </li>
+</ol>

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -231,6 +231,15 @@ describe('Token:', function () {
       assertTok(t.next(), 'whitespace', ' ');
       assertTok(t.next(), 'text', '--foo');
     });
+
+    it('is not greedy', function () {
+      const t = new Tokenizer('foo<!-- -->bar<!-- -->baz');
+      assertTok(t.next(), 'text', 'foo');
+      assertTok(t.next(), 'comment', '<!-- -->');
+      assertTok(t.next(), 'text', 'bar');
+      assertTok(t.next(), 'comment', '<!-- -->');
+      assertTok(t.next(), 'text', 'baz');
+    });
   });
 
   describe('HTML tags', function () {


### PR DESCRIPTION
Oddly enough I think this bug existed in the old implementation as well. One character fix (and many characters of tests :))