### PR TITLE
Fix parse error with consecutive formats

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -121,14 +121,19 @@ module.exports = class Parser {
       } else if (tok.name === 'text' || tok.name === 'whitespace' || tok.name === 'linebreak') {
         seg.push(this.parseText(inList, fmtStack));
       } else if (isFormatToken(tok)) {
-        if (fmtStack.indexOf(tok.name) === -1) {
-          const node = this.parseFormat(tok.name, inList, fmtStack);
-          seg = seg.concat(node);
-        } else {
+        if (fmtStack.indexOf(tok.name) > -1) { // only one format
           // this format token closes a format on the stack so ends this fragment
           // parseText handles checking for whether the close format was contextually
           // valid
           break;
+        } else if (fmtStack.length === 0) {
+          // valid format
+          const node = this.parseFormat(tok.name, inList, fmtStack);
+          seg = seg.concat(node);
+        } else {
+          // invalid format
+          pushOrJoin(seg, { name: 'text', contents: tok.contents });
+          this._t.next();
         }
       } else if (tok.name === 'comment' || tok.name === 'tag') {
         seg.push(tok);

--- a/test/list-cases/code.ecmarkdown
+++ b/test/list-cases/code.ecmarkdown
@@ -3,5 +3,6 @@
 1. The `stream.state` should be `"readable"`.
 1. `"strings"` are often in code, sometimes at the beginning.
 1. `Code can contain spaces`.
+1. Code can have formats in them, like so: `||`, `**`, `__`, and `~~`.
 1. Leftover backticks `code`cannot` get left there.
 1. If they're balanced though, it works: `perhaps`unanticipated`?`.

--- a/test/list-cases/code.html
+++ b/test/list-cases/code.html
@@ -4,6 +4,7 @@
   <li>The <code>stream.state</code> should be <code>"readable"</code>.</li>
   <li><code>"strings"</code> are often in code, sometimes at the beginning.</li>
   <li><code>Code can contain spaces</code>.</li>
+  <li>Code can have formats in them, like so: <code>||</code>, <code>**</code>, <code>__</code>, and <code>~~</code>.</li>
   <li>Leftover backticks <code>code</code>cannot` get left there.</li>
   <li>If they're balanced though, it works: <code>perhaps</code>unanticipated<code>?</code>.</li>
 </ol>


### PR DESCRIPTION
Input such as `*__*` or tick + `||` + tick presently throws.

(Found by compiling @jmdyck's spec conversion)