### PR TITLE
Consume trailing linebreak in files and after list-items

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -28,8 +28,7 @@ function emit(node) {
     }).join('');
     str += '</' + node.name + '>';
   } else if (node.name === 'text') {
-    // trim any trailing line breaks and indents
-    str += node.contents.replace(/\n+\s*$/, '');
+    str += node.contents;
   } else if (node.name === 'pipe') {
     str += '<emu-nt';
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -145,7 +145,7 @@ module.exports = class Parser {
         seg.push(tok);
         this._t.next();
       } else if (isList(tok)) {
-        if (inList && this._t.previous.name === 'linebreak') {
+        if (inList) {
           break;
         } else {
           pushOrJoin(seg, { name: 'text', contents: tok.contents });
@@ -167,6 +167,15 @@ module.exports = class Parser {
 
     while (true) {
       const tok = this._t.peek();
+
+      if (tok.name === 'linebreak') {
+        const next = this._t.peek(2);
+        // consume linebreaks trailing list items and before EOF
+        if (next.name === 'EOF' || (inList && isList(next))) {
+          this._t.next();
+          break;
+        }
+      }
 
       if (tok.name === 'text' || isWhitespace(tok)) {
         node.contents += tok.contents;

--- a/test/list-cases/mangled-list-items.html
+++ b/test/list-cases/mangled-list-items.html
@@ -1,5 +1,5 @@
 <ul>
-  <li>normal list item*this one is mangled.
+  <li>normal list item *this one is mangled.
     <ol>
       <li>normal list item 1.this one is mangled 1this one is even more mangled this is a normal line of text</li>
     </ol>

--- a/test/paragraph-cases/linebreaks.ecmarkdown
+++ b/test/paragraph-cases/linebreaks.ecmarkdown
@@ -1,0 +1,3 @@
+if a paragraph contains a linebreak, it should preserve the linebreak in
+the output (before beautification) and even if a line starts with a
+~format~, line breaks are preserved

--- a/test/paragraph-cases/linebreaks.html
+++ b/test/paragraph-cases/linebreaks.html
@@ -1,0 +1,2 @@
+<p>if a paragraph contains a linebreak, it should preserve the linebreak in the output (before beautification) and even if a line starts with a
+  <emu-const>format</emu-const>, line breaks are preserved</p>


### PR DESCRIPTION
This fixes the issue raised here: https://github.com/bterlson/ecmarkup/issues/43.