### PR TITLE
Don't consider empty formats valid (eg. __)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -242,7 +242,10 @@ module.exports = class Parser {
     } else {
       this._t.next(); // consume end format.
 
-      if (node.name === 'pipe') {
+      if (node.contents.length === 0) {
+        // empty formats not allowed
+        return [{ name: 'text', contents: startTok.contents + endTok.contents }];
+      } else if (node.name === 'pipe') {
         const ntNode = parseNonTerminal(node.contents[0].contents);
 
         if (ntNode === null) {

--- a/test/fragment-cases/dunderproto.ecmarkdown
+++ b/test/fragment-cases/dunderproto.ecmarkdown
@@ -1,0 +1,1 @@
+__proto__ should ~~render~~ as normal since __proto__ doesn't have **underscores** with any content in them.

--- a/test/fragment-cases/dunderproto.html
+++ b/test/fragment-cases/dunderproto.html
@@ -1,0 +1,1 @@
+__proto__ should ~~render~~ as normal since __proto__ doesn&#39;t have **underscores** with any content in them.


### PR DESCRIPTION
Fixes tc39/ecma262#136 and bterlson/ecmarkup#66.