### PR TITLE
Fix minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Lists can be nested. To do so, use any number of spaces to indent; as long as th
 
 Within a fragment, the following can be used:
 
-**Variables** are written as `_x_` and are translated to `<var>x</var>`. Variables cannot contain whitespace or other formatting characters. You can use variables adjacent to other characters, e.g. as in `_SIMD_Constructor`, as long as the start of the variable is preceded by whitespace (e.g. `my_SIMD_constructor` does not contain any variables).
+**Variables** are written as `_x_` and are translated to `<var>x</var>`. Variables cannot contain whitespace or other formatting characters.
 
 **Values** are written as `*x*` and are translated to `<emu-val>x</emu-val>`. Values cannot contain asterisks.
 
@@ -99,7 +99,9 @@ Within a fragment, the following can be used:
 
 **Spec-level constants** are written as `~x~` and are translated to `<emu-const>x</emu-const>`. Spec-level constants cannot contain tildes.
 
-**Nonterminals** are written as `|x|`, `|x_opt|`, `|x[p]|`, or `|x[p]_opt|`. These are translated, respectively, into `<emu-nt>x</emu-nt>`, `<emu-nt optional>x</emu-nt>`, `<emu-nt params="p">x</emu-nt>`, or `<emu-nt params="p" optional>x</emu-nt>`. Nonterminal names can only be composed of letters. Params can be composed of anything except a closing square bracket.
+**Nonterminals** are written as `|x|`, `|x_opt|`, `|x[p]|`, or `|x[p]_opt|`. These are translated, respectively, into `<emu-nt>x</emu-nt>`, `<emu-nt optional>x</emu-nt>`, `<emu-nt params="p">x</emu-nt>`, or `<emu-nt params="p" optional>x</emu-nt>`. Nonterminal names can only be composed of letters and numbers. Params can be composed of anything except a closing square bracket.
+
+All formats can be started following non-alphanumeric and non-whitespace characters and can be ended following any non-whitespace character. The one exception is code formats which can begin and end in any context.  For example, `my_SIMD_constructor` does not contain any variables while `_SIMD_Constructor` does.
 
 You can escape any format above with a backslash. Escaping of any non-format characters will not be considered an escape and will render literally (eg. `\a` simply renders as `\a`). If you need a literal backslash before a formatting character, you must escape the backslash (eg. `\\*foo*` renders as `\<emu-val>foo</emu-val>`).
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -325,7 +325,7 @@ function unshiftOrJoin(list, node) {
 
 // Parsing of non-terminals, eg. |foo[?Param]_opt|
 // TODO: Rationalize with Grammarkdown (? instead of _opt)
-const nonTerminalRe = /^([A-Za-z]+)(?:\[([^\]]+)\])?(_opt)?$/;
+const nonTerminalRe = /^([A-Za-z0-9]+)(?:\[([^\]]+)\])?(_opt)?$/;
 function parseNonTerminal(str) {
   const match = str.match(nonTerminalRe);
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -206,7 +206,7 @@ module.exports = class Parser {
           const onStack = fmtStack.indexOf(tok.name) > -1;
 
           if ((!onStack && isValidStartFormat(prev, tok, next)) ||
-              (onStack && isValidEndFormat(prev, tok, next))) {
+              (onStack && isValidEndFormat(prev, tok))) {
             break;
           }
         }
@@ -295,12 +295,12 @@ function isValidStartFormat(prev, cur, next) {
   return !isAlphaNumeric(prev.contents[prev.contents.length - 1]) && !isWhitespace(next);
 }
 
-function isValidEndFormat(prev, cur, next) {
+function isValidEndFormat(prev, cur) {
   if (cur.name === 'tick') {
     return true;
   }
 
-  return !isWhitespace(prev) && (next.name === 'EOF' || !isAlphaNumeric(next.contents[0]));
+  return !isWhitespace(prev);
 }
 
 // appends a text token or appends to the last token's contents if the last token is text

--- a/test/list-cases/nonterminals.ecmarkdown
+++ b/test/list-cases/nonterminals.ecmarkdown
@@ -1,4 +1,5 @@
 1. |NonTerminalName|
+1. |NonTerminalName4You|
 1. |NonTerminalName_opt|
 1. |NonTerminalName[Parameter1]|
 1. |NonTerminalName[Parameter1, ?Parameter2]_opt|

--- a/test/list-cases/nonterminals.html
+++ b/test/list-cases/nonterminals.html
@@ -1,5 +1,6 @@
 <ol>
   <li><emu-nt>NonTerminalName</emu-nt></li>
+  <li><emu-nt>NonTerminalName4You</emu-nt></li>
   <li><emu-nt optional>NonTerminalName</emu-nt></li>
   <li><emu-nt params="Parameter1">NonTerminalName</emu-nt></li>
   <li><emu-nt params="Parameter1, ?Parameter2" optional>NonTerminalName</emu-nt></li>

--- a/test/paragraph-cases/formats-in-text.ecmarkdown
+++ b/test/paragraph-cases/formats-in-text.ecmarkdown
@@ -1,0 +1,1 @@
+*star*s s*tars* _var_s v_ars_ `tick`s t`icks` |pipe|s p|ipes| ~tilde~s t~ildes~

--- a/test/paragraph-cases/formats-in-text.html
+++ b/test/paragraph-cases/formats-in-text.html
@@ -1,0 +1,2 @@
+<p><emu-val>star</emu-val>s s*tars* <var>var</var>s v_ars_ <code>tick</code>s t<code>icks</code> <emu-nt>pipe</emu-nt>s p|ipes| <emu-const>tilde</emu-const>s t~ildes~
+</p>


### PR DESCRIPTION
* Allow numerals in non-terminals (eg. Hex4Digits).
* Allow formats to end in the middle of text (eg. `|FunctionDeclaration|s`).
